### PR TITLE
Updated .Net 10

### DIFF
--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 3.1
+        dotnet-version: 10
     - name: Install dependencies
       run: dotnet restore
     - name: Build

--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -12,9 +12,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Setup .NET Core
-      uses: actions/setup-dotnet@v1
+      uses: actions/setup-dotnet@v4
       with:
         dotnet-version: 10
     - name: Install dependencies

--- a/src/JusticeApp.Tests/JusticeApp.Tests.csproj
+++ b/src/JusticeApp.Tests/JusticeApp.Tests.csproj
@@ -1,16 +1,16 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
-    <PackageReference Include="xunit" Version="2.4.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
-    <PackageReference Include="coverlet.collector" Version="1.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
+    <PackageReference Include="coverlet.collector" Version="6.0.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/JusticeApp/JusticeApp.csproj
+++ b/src/JusticeApp/JusticeApp.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
 
-</Project>
+</Project> 


### PR DESCRIPTION
This pull request updates the project to target .NET 10 and upgrades related dependencies. The main changes focus on modernizing the build environment and updating test dependencies to their latest versions.

**.NET version upgrade:**
- Changed the target framework from `net8.0` to `net10.0` in both `JusticeApp.csproj` and `JusticeApp.Tests.csproj` to use the latest .NET features and improvements. [[1]](diffhunk://#diff-b674bb7761567a75588ac16be501ef10669c3fc7a9bb9bfb02dc3e490b391d51L4-R4) [[2]](diffhunk://#diff-f0af7c2c772f96e3096f01ea48c546fa0bebb47de3a3ec92de686fdfeb9996d0L4-R13)
- Updated the GitHub Actions workflow to use .NET Core version 10 for CI builds.

**Dependency updates for testing:**
- Upgraded `Microsoft.NET.Test.Sdk` from `16.5.0` to `18.0.1`, `xunit` from `2.4.0` to `2.9.3`, `xunit.runner.visualstudio` from `2.4.3` to `3.1.5`, and `coverlet.collector` from `1.2.0` to `6.0.4` in `JusticeApp.Tests.csproj` for improved test performance and compatibility.